### PR TITLE
Brand migration: Update Ambiware → Loqa Labs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Ambiware Labs
+Copyright (c) 2024 Loqa Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 
 Individual skills may have their own licenses. The repository structure and documentation are licensed under the MIT License.
 
-## About Ambiware Labs
+## About Loqa Labs
 
-Loqa is developed by [Ambiware Labs](https://ambiware.ai), building the future of local-first ambient intelligence.
+Loqa is developed by [Loqa Labs](https://ambiware.ai), building the future of local-first ambient intelligence.


### PR DESCRIPTION
Updates all brand name references from Ambiware to Loqa Labs.

Migration Phase: Phase 2.3 - Repository Updates